### PR TITLE
Support for non-nullable strings in Swagger

### DIFF
--- a/src/Homely.AspNetCore.Mvc.Helpers/Homely.AspNetCore.Mvc.Helpers.csproj
+++ b/src/Homely.AspNetCore.Mvc.Helpers/Homely.AspNetCore.Mvc.Helpers.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     </ItemGroup>
 
 </Project>

--- a/tests/TestWebApplication/Controllers/TestController.cs
+++ b/tests/TestWebApplication/Controllers/TestController.cs
@@ -28,12 +28,12 @@ namespace TestWebApplication.Controllers
 
         // GET: /test/1 | 200 OK.
         [HttpGet("{id:int}", Name = "GetId")]
-        public IActionResult Get(int id)
+        public ActionResult<FakeVehicle> Get(int id)
         {
             var model = _fakeVehicleRepository.Get(id);
 
             return model == null
-                ? (IActionResult)NotFound()
+                ? (ActionResult<FakeVehicle>) NotFound()
                 : Ok(model);
         }
 

--- a/tests/TestWebApplication/Models/FakeVehicle.cs
+++ b/tests/TestWebApplication/Models/FakeVehicle.cs
@@ -1,8 +1,13 @@
-﻿namespace TestWebApplication.Models
+﻿using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+
+namespace TestWebApplication.Models
 {
     public class FakeVehicle
     {
         public int Id { get; set; }
+
+        [Required]
         public string Name { get; set; }
         public string RegistrationNumber { get; set; }
         public ColourType Colour { get; set; }


### PR DESCRIPTION
- Upgraded Swashbuckle.AspNetCore to 5.4.1 ([here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1571) is the fix we need)
- Updated sample app to have non-nullable string