### PR TITLE
:wrench: Display the calling assembly info, by default.

### DIFF
--- a/src/Homely.AspNetCore.Mvc.Helpers/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Homely.AspNetCore.Mvc.Helpers/Extensions/IServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
+using System.Reflection;
 
 namespace Homely.AspNetCore.Mvc.Helpers.Extensions
 {
@@ -72,7 +73,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Extensions
                                                                   Func<ApiDescription, string> operationIdSelector = null)
         {
             services.AddControllers()
-                    .AddAHomeController(services, banner)
+                    .AddAHomeController(services, banner, Assembly.GetCallingAssembly())
                     .AddDefaultJsonOptions(isJsonIndented, jsonDateTimeFormat);
 
             services.AddProblemDetails(options =>


### PR DESCRIPTION
This way, the correct text is shown here:

```
Some Test Api
Name: TestWebApplication   <--- HERE
Version: 1.0.0.0
Build Date : Wednesday, 19 August 2020 3:59:47 AM
Application Started: Wednesday, 19 August 2020 3:59:55 AM
Server name: PUREKROME-PC2
```