### PR TITLE
Update Homely.AspNetCore.Mvc.Helpers to show local datetime instead of UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build version suffix
         run: echo "VERSION_SUFFIX=beta.${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
 
       - run: dotnet restore --verbosity minimal
 
@@ -34,7 +34,7 @@ jobs:
       - run: dotnet pack --configuration Release --no-build --output ./artifacts --version-suffix $VERSION_SUFFIX
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./artifacts/*
 
@@ -46,7 +46,7 @@ jobs:
             --source https://nuget.pkg.github.com/${{ github.repository_owner }}
 
       - name: Remove old pre-release packages (keeping the GPR cleanish)
-        uses: actions/delete-package-versions@v2
+        uses: actions/delete-package-versions@v4
         with: 
           package-name: 'Homely.AspNetCore.Mvc.Helpers'
           min-versions-to-keep: 10
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
 
       - run: dotnet restore --verbosity minimal
 
@@ -69,7 +69,7 @@ jobs:
       - run: dotnet test --configuration Debug --verbosity minimal --no-build --collect:"XPlat Code Coverage" --results-directory "./.codecoverage"
 
       - name: Code coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
           directory: "./.codecoverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             --source https://nuget.pkg.github.com/${{ github.repository_owner }}
 
       - name: Remove old pre-release packages (keeping the GPR cleanish)
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with: 
           package-name: 'Homely.AspNetCore.Mvc.Helpers'
           min-versions-to-keep: 10

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build version suffix
         run: echo "VERSION_SUFFIX=alpha.${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
 
       - run: dotnet restore --verbosity minimal
 
@@ -29,7 +29,7 @@ jobs:
       - run: dotnet pack --configuration Release --no-build --output ./artifacts --version-suffix $VERSION_SUFFIX
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./artifacts/*
 
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
 
       - run: dotnet restore --verbosity minimal
 
@@ -50,7 +50,7 @@ jobs:
       - run: dotnet test --configuration Debug --verbosity minimal --no-build --collect:"XPlat Code Coverage" --results-directory "./.codecoverage"
 
       - name: Code coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"
           directory: "./.codecoverage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
 
       - run: dotnet restore --verbosity minimal
 
@@ -35,12 +35,12 @@ jobs:
       - run: dotnet pack --configuration Release --no-build --output ./artifacts /p:version=${{ env.RELEASE_VERSION }}
 
       - name: Publish artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./artifacts/*
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100",
+        "version": "8.0.400",
         "rollForward": "latestFeature"
     }
   }

--- a/src/Homely.AspNetCore.Mvc.Helpers/Homely.AspNetCore.Mvc.Helpers.csproj
+++ b/src/Homely.AspNetCore.Mvc.Helpers/Homely.AspNetCore.Mvc.Helpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -22,14 +22,14 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.3.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Homely.AspNetCore.Mvc.Helpers/Models/HomeControllerBanner.cs
+++ b/src/Homely.AspNetCore.Mvc.Helpers/Models/HomeControllerBanner.cs
@@ -6,18 +6,18 @@ namespace Homely.AspNetCore.Mvc.Helpers.Models
     /// <inheritdoc/>
     public class HomeControllerBanner : IHomeControllerBanner
     {
-        private static readonly DateTime ApplicationStartedOn = DateTime.UtcNow;
+        private static readonly DateTime ApplicationStartedOn = DateTime.Now;
 
         public HomeControllerBanner(Assembly callingAssembly, string? banner = null)
         {
             var assemblyDate = callingAssembly.Location == null
                                    ? "-- unknown --"
-                                   : System.IO.File.GetLastWriteTime(callingAssembly.Location).ToString("U");
+                                   : System.IO.File.GetLastWriteTime(callingAssembly.Location).ToString("F");
 
             var assemblyInfo = $"Name: {callingAssembly.GetName().Name}{Environment.NewLine}" +
                                    $"Version: {callingAssembly.GetName().Version}{Environment.NewLine}" +
                                    $"Build Date : {assemblyDate}{Environment.NewLine}" +
-                                   $"Application Started: {ApplicationStartedOn:U}";
+                                   $"Application Started: {ApplicationStartedOn:F}";
 
             var serverDetails = $"Server name: {Environment.MachineName}";
 

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/HomeControllerTests/ExceptionTestTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/HomeControllerTests/ExceptionTestTests.cs
@@ -24,7 +24,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.HomeControllerTests
             // Arrange.
             var expectedError = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/500",
+                Type = "https://httpstatuses.io/500",
                 Title = "Internal Server Error",
                 Status = StatusCodes.Status500InternalServerError
             };

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/HomeControllerTests/GetTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/HomeControllerTests/GetTests.cs
@@ -1,7 +1,8 @@
-﻿using Homely.AspNetCore.Mvc.Helpers.Extensions;
+using Homely.AspNetCore.Mvc.Helpers.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,11 +22,12 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.HomeControllerTests
         {
             // Arrange.
             const string banner = "pew pew";
+            var currentAssembly = Assembly.GetExecutingAssembly();
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureServices(services =>
                 {
-                    services.AddControllers().AddAHomeController(services, banner);
+                    services.AddControllers().AddAHomeController(services, banner, currentAssembly);
                 });
             }).CreateClient();
 
@@ -36,6 +38,10 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.HomeControllerTests
             response.IsSuccessStatusCode.ShouldBeTrue();
             var text = await response.Content.ReadAsStringAsync();
             text.ShouldStartWith(banner); // Banner ASCII art/text.
+
+            var buildDate = System.IO.File.GetLastWriteTime(currentAssembly.Location).ToString("F");
+
+            text.ShouldContain(buildDate);
         }
     }
 }

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/Homely.AspNetCore.Mvc.Helpers.Tests.csproj
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/Homely.AspNetCore.Mvc.Helpers.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ConflictTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ConflictTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shouldly;
 using System;
@@ -23,7 +23,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             // Arrange.
             var error = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/409",
+                Type = "https://httpstatuses.io/409",
                 Title = "Agent was already modified.",
                 Status = StatusCodes.Status409Conflict,
                 Detail = "agent was already modified after you retrieved the latest data. So you would then override the most recent copy. As such, you will need to refresh the page (to get the latest data) then modify that, if required.",

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/DynamicErrorTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/DynamicErrorTests.cs
@@ -25,7 +25,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             const string route = "/test/dynamicError";
             var error = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/500",
+                Type = "https://httpstatuses.io/500",
                 Title = "Internal Server Error",
                 Status = StatusCodes.Status500InternalServerError
             };

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ErrorTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ErrorTests.cs
@@ -23,7 +23,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             // Arrange.
             var error = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/500",
+                Type = "https://httpstatuses.io/500",
                 Title = "Internal Server Error",
                 Status = StatusCodes.Status500InternalServerError
             };

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/GetNotFoundTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/GetNotFoundTests.cs
@@ -23,7 +23,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             // Arrange.
             var error = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/404",
+                Type = "https://httpstatuses.io/404",
                 Title = "Not Found",
                 Status = StatusCodes.Status404NotFound
             };

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/GetTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/GetTests.cs
@@ -41,7 +41,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             const int id = int.MaxValue;
             var error = new ProblemDetails
             {
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.4",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.5",
                 Title = "Not Found",
                 Status = StatusCodes.Status404NotFound
             };

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ModelBindingTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/ModelBindingTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shouldly;
 using System;
@@ -34,7 +34,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
             // Arrange.
             var error = new ValidationProblemDetails
             {
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
                 Title = "One or more validation errors occurred.",
                 Status = StatusCodes.Status400BadRequest,
                 Detail = "Please refer to the errors property for additional details.",

--- a/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/PostTests.cs
+++ b/tests/Homely.AspNetCore.Mvc.Helpers.Tests/TestControllerTests/PostTests.cs
@@ -68,7 +68,7 @@ namespace Homely.AspNetCore.Mvc.Helpers.Tests.TestControllerTests
 
             var error = new ValidationProblemDetails
             {
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+                Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1",
                 Title = "One or more validation errors occurred.",
                 Status = StatusCodes.Status400BadRequest,
                 Detail = "Please refer to the errors property for additional details.",

--- a/tests/TestWebApplication/Controllers/TestController.cs
+++ b/tests/TestWebApplication/Controllers/TestController.cs
@@ -97,7 +97,7 @@ namespace TestWebApplication.Controllers
         {
             var error = new ProblemDetails
             {
-                Type = "https://httpstatuses.com/409",
+                Type = "https://httpstatuses.io/409",
                 Title = "Agent was already modified.",
                 Status = StatusCodes.Status409Conflict,
                 Instance = "/test/conflict",

--- a/tests/TestWebApplication/TestWebApplication.csproj
+++ b/tests/TestWebApplication/TestWebApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# References
- [JIRA](https://homelyau.atlassian.net/browse/HDW-8433)

# Summary
The API home endpoint is currently showing the build date and applications started with UTC format. It needs to be changed into local date time format

- Migrate projects to NET 8
- Bump nuget packages versions
- Bump GitHub actions versions
- Fix existing UTs

# Code Checklist
- [x] Branch name using correct convention
- [x] Coding standards adhered to
- [x] PR is as small as it can be (no bundled changes)
- [x] Tests added

# JIRA Checklist
- [ ] Technical notes / screenshots
- [x] Deployment plan
- [ ] Performance results (if applicable)


